### PR TITLE
fix: version of download and upload artifacts has been upgraded

### DIFF
--- a/.github/workflows/backend-workflow.yml
+++ b/.github/workflows/backend-workflow.yml
@@ -84,7 +84,7 @@ jobs:
 
       # Upload the build artifacts
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: .aws-sam/
@@ -231,7 +231,7 @@ jobs:
 
       # Download the build artifacts
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
       


### PR DESCRIPTION
The deprecated versions of download and upload actions have been removed and replaced with the latest versions.